### PR TITLE
Output one line per PES packet in SMPTE 2038

### DIFF
--- a/input/sdi/decklink/decklink.cpp
+++ b/input/sdi/decklink/decklink.cpp
@@ -195,7 +195,7 @@ static int transmit_pes_to_muxer(decklink_ctx_t *decklink_ctx, uint8_t *buf, uin
  * VANC parser. We'll expect our VANC message callbacks to happen on this
  * same calling thread.
  */
-static void convert_colorspace_and_parse_vanc(struct vanc_context_s *vanchdl, unsigned char *buf, unsigned int uiWidth, unsigned int lineNr)
+static void convert_colorspace_and_parse_vanc(decklink_ctx_t *decklink_ctx, struct vanc_context_s *vanchdl, unsigned char *buf, unsigned int uiWidth, unsigned int lineNr)
 {
 	/* Convert the vanc line from V210 to CrCB422, then vanc parse it */
 
@@ -218,10 +218,25 @@ static void convert_colorspace_and_parse_vanc(struct vanc_context_s *vanchdl, un
 	if (klvanc_v210_line_to_nv20_c(src, p_anc, sizeof(decoded_words), (uiWidth / 6) * 6) < 0)
 		return;
 
+    if (decklink_ctx->smpte2038_ctx)
+        smpte2038_packetizer_begin(decklink_ctx->smpte2038_ctx);
+
 	int ret = vanc_packet_parse(vanchdl, lineNr, decoded_words, sizeof(decoded_words) / (sizeof(unsigned short)));
 	if (ret < 0) {
-		/* No VANC on this line */
+        /* No VANC on this line */
 	}
+
+    if (decklink_ctx->smpte2038_ctx) {
+        if (smpte2038_packetizer_end(decklink_ctx->smpte2038_ctx,
+                                     decklink_ctx->stream_time / 300) == 0) {
+
+            if (transmit_pes_to_muxer(decklink_ctx, decklink_ctx->smpte2038_ctx->buf,
+                                      decklink_ctx->smpte2038_ctx->bufused) < 0) {
+                fprintf(stderr, "%s() failed to xmit PES to muxer\n", __func__);
+            }
+        }
+    }
+
 }
 
 static void setup_pixel_funcs( decklink_opts_t *decklink_opts )
@@ -397,10 +412,6 @@ HRESULT DeckLinkCaptureDelegate::VideoInputFrameArrived( IDeckLinkVideoInputFram
 
     if( videoframe )
     {
-        /* At the beginning of each video frame, prepare the smpte2038 packetizer */
-        if (decklink_ctx->smpte2038_ctx)
-            smpte2038_packetizer_begin(decklink_ctx->smpte2038_ctx);
-
         if( videoframe->GetFlags() & bmdFrameHasNoInputSource )
         {
             syslog( LOG_ERR, "Decklink card index %i: No input signal detected", decklink_opts_->card_idx );
@@ -467,8 +478,8 @@ HRESULT DeckLinkCaptureDelegate::VideoInputFrameArrived( IDeckLinkVideoInputFram
             if( ancillary->GetBufferForVerticalBlankingLine( line, &anc_line ) == S_OK ) {
 
                 /* Give libklvanc a chance to parse all vanc, and call our callbacks (same thread) */
-                convert_colorspace_and_parse_vanc(decklink_ctx->vanchdl, (unsigned char *)anc_line,
-                                                  width, line);
+                convert_colorspace_and_parse_vanc(decklink_ctx, decklink_ctx->vanchdl,
+                                                  (unsigned char *)anc_line, width, line);
 
                 decklink_ctx->unpack_line( (uint32_t*)anc_line, anc_buf_pos, width );
             } else
@@ -641,32 +652,6 @@ HRESULT DeckLinkCaptureDelegate::VideoInputFrameArrived( IDeckLinkVideoInputFram
             decklink_ctx->non_display_parser.num_vbi = 0;
             decklink_ctx->non_display_parser.num_anc_vbi = 0;
         }
-
-        /* At the end of each video frame, complete the smpte2038 packetizer.
-	 * collect the single PES frame, pass it to the output TS mux.
-	 */
-        if (decklink_ctx->smpte2038_ctx) {
-            if (smpte2038_packetizer_end(decklink_ctx->smpte2038_ctx,
-                                         decklink_ctx->stream_time / 300) == 0) {
-
-#if 0
-                /* buf: smpte2038_ctx->buf count:smpte2038_ctx->bufused */
-                static int idx = 0;
-                char fn[64];
-                sprintf(fn, "/tmp/pes%08d.bin", idx++);
-                FILE *fh = fopen(fn, "a+");
-                if (fh) {
-                    printf("Writing SMPTE2038 PES to %s\n", fn);
-                    fwrite(decklink_ctx->smpte2038_ctx->buf, 1, decklink_ctx->smpte2038_ctx->bufused, fh);
-                    fclose(fh);
-                }
-#endif
-		if (transmit_pes_to_muxer(decklink_ctx, decklink_ctx->smpte2038_ctx->buf, decklink_ctx->smpte2038_ctx->bufused) < 0) {
-			fprintf(stderr, "%s() failed to xmit PES to muxer\n", __func__);
-		}
-            }
-        }
-
     } /* if video frame */
 
     /* TODO: probe SMPTE 337M audio */


### PR DESCRIPTION
The existing code would create a PES packet which contained all
VANC packets for all the lines corresponding to a given video frame.
However the spec calls for exactly one line's worth of VANC packets
to be present in a given PES packet.

From the spec (SMPTE 2038-2008 Sec 4.2):

Each ANC data PES packet shall contain ANC data from no more than
one line. ANC data packets extracted from the same line shall be
conveyed in the same ANC data PES packet.