### PR TITLE
When receiving SDI data in the PSF video format, treat as interlaced

### DIFF
--- a/input/sdi/decklink/decklink.cpp
+++ b/input/sdi/decklink/decklink.cpp
@@ -493,6 +493,22 @@ public:
                 decklink_opts_->timebase_num = video_format_tab[i].timebase_num;
                 decklink_opts_->timebase_den = video_format_tab[i].timebase_den;
 
+		if (decklink_opts_->video_format == INPUT_VIDEO_FORMAT_1080P_2997)
+		{
+		   if (p_display_mode->GetFieldDominance() == bmdProgressiveSegmentedFrame)
+		   {
+		       /* HACK: The transport is structurally interlaced, so we need
+			  to treat it as such in order for VANC processing to
+			  work properly (even if the actual video really may be
+			  progressive).  This also coincidentally works around a bug
+			  in VLC where 1080i/59 content gets put out as 1080psf/29, and
+			  that's a much more common use case in the broadcast world
+			  than real 1080 progressive video at 30 FPS. */
+		       fprintf(stderr, "Treating 1080psf/30 as interlaced\n");
+		       decklink_opts_->video_format = INPUT_VIDEO_FORMAT_1080I_5994;
+		   }
+		}
+
                 get_format_opts( decklink_opts_, p_display_mode );
                 setup_pixel_funcs( decklink_opts_ );
 


### PR DESCRIPTION
Decklink Duo2 cards properly detect 1080psf/30 video, but the
drivers still expect you to refer to VANC lines using their
interlaced line numbers (i.e. refer to lines in the second field
 with numbers 570...).  In order to ensure OBE properly parses
VANC in these lines, treat the PSF video format as interlaced.

This doesn't appear to occur with the original Decklink Duo cards
because they detect streams in the PSF video format as 1080i/59,
rather than 1080psf/30.  Hence it works because it's treating it
as interlaced because it doesn't know any better.